### PR TITLE
Update Content Provider to 1.3.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-elimuContentProvider = "1.3.5"
+elimuContentProvider = "1.3.6"
 material = "1.12.0"
 junit = "4.13.2"
 glide = "4.16.0"


### PR DESCRIPTION
Update Content Provider to 1.3.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of the elimuContentProvider dependency for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->