### PR TITLE
Include current playback timestamp in `additionalData` when reporting VideoLearningEvent

### DIFF
--- a/app/src/main/java/ai/elimu/filamu/ui/video/VideoActivity.kt
+++ b/app/src/main/java/ai/elimu/filamu/ui/video/VideoActivity.kt
@@ -23,6 +23,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import dagger.hilt.android.AndroidEntryPoint
+import org.json.JSONObject
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -89,11 +90,15 @@ class VideoActivity : AppCompatActivity() {
 
                     if (playbackState == Player.STATE_ENDED) {
                         videoTitle = intent.getStringExtra(EXTRA_KEY_VIDEO_TITLE) ?: ""
+                        val extraData = JSONObject().apply {
+                            put(ANALYTICS_PLAYBACK_POSITION, videoPlayer.duration)
+                        }
                         LearningEventUtil.reportVideoLearningEvent(
                             videoGson = VideoGson().apply {
                                 id = videoId
                                 title = videoTitle
                             },
+                            additionalData = extraData,
                             learningEventType = LearningEventType.VIDEO_COMPLETED,
                             context = this@VideoActivity,
                             analyticsApplicationId = BuildConfig.ANALYTICS_APPLICATION_ID)
@@ -124,18 +129,23 @@ class VideoActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        videoPlayer.release()
+
         if (!isVideoPlaybackCompleted) {
+            val extraData = JSONObject().apply {
+                put(ANALYTICS_PLAYBACK_POSITION, videoPlayer.currentPosition)
+            }
             LearningEventUtil.reportVideoLearningEvent(
                 videoGson = VideoGson().apply {
                     id = videoId
                     title = videoTitle
                 },
+                additionalData = extraData,
                 learningEventType = LearningEventType.VIDEO_CLOSED_BEFORE_COMPLETION,
                 context = this@VideoActivity,
                 analyticsApplicationId = BuildConfig.ANALYTICS_APPLICATION_ID)
         }
 
+        videoPlayer.release()
     }
 
     private fun initViewModels() {
@@ -145,5 +155,7 @@ class VideoActivity : AppCompatActivity() {
     companion object {
         const val EXTRA_KEY_VIDEO_ID: String = "extra_key_video_id"
         const val EXTRA_KEY_VIDEO_TITLE = "extra_key_video_title"
+
+        private const val ANALYTICS_PLAYBACK_POSITION = "video_playback_position_ms"
     }
 }


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #93 

### Purpose
Include current playback timestamp in `additionalData` when reporting VideoLearningEvent

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [x] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)

#### Content Tests
<!-- Did you verify that your changes are compatible with different types of content? -->
- [ ] I tested my changes with English content (`eng.elimu.ai`)
- [ ] I tested my changes with Hindi content (`hin.elimu.ai`)
- [ ] I tested my changes with Tagalog content (`tgl.elimu.ai`)
- [ ] I tested my changes with Thai content (`tha.elimu.ai`)
- [ ] I tested my changes with Vietnamese content (`vie.elimu.ai`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Video analytics now include playback position data when a video is completed or closed before finishing.

- **Bug Fixes**
	- Ensured analytics are reported before releasing the video player when exiting the video screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->